### PR TITLE
docs: align with cli v0.1.23 (soul->soul-id, full higgsfield names)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ assignees: ""
 
 ## What actually happened
 
-<!-- Paste relevant agent output or `hf` CLI output. Redact API keys. -->
+<!-- Paste relevant agent output or `higgsfield` CLI output. Redact API keys. -->
 
 ```
 ```
@@ -39,7 +39,7 @@ assignees: ""
 ## Environment
 
 - Agent: <!-- Claude Code / Cursor / Codex / other -->
-- `hf --version`:
+- `higgsfield version`:
 - OS:
 - Skills version (`cat VERSION`):
 

--- a/.github/ISSUE_TEMPLATE/new_skill_request.md
+++ b/.github/ISSUE_TEMPLATE/new_skill_request.md
@@ -37,7 +37,7 @@ assignees: ""
 
 ## Backing API or CLI command
 
-<!-- e.g. `hf <noun> <verb>`. If the CLI command doesn't exist yet, link to the CLI issue/PR. -->
+<!-- e.g. `higgsfield <noun> <verb>`. If the CLI command doesn't exist yet, link to the CLI issue/PR. -->
 
 ## Sketch of the SKILL.md
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 
 ## Testing
 
-<!-- How you verified this works. Paste relevant agent output, hf CLI output, or test scenarios. -->
+<!-- How you verified this works. Paste relevant agent output, higgsfield CLI output, or test scenarios. -->
 
 - [ ]
 - [ ]
@@ -33,7 +33,7 @@
 - [ ] All `references/X.md` links in `SKILL.md` resolve; no orphan reference files; no `../` parent-dir references.
 - [ ] If a skill folder was added or renamed, `marketplace.json` reflects it.
 - [ ] If user-facing behavior changed, `SKILL.md` and `README.md` reflect it.
-- [ ] Every `hf …` example in the docs is a real, current command.
+- [ ] Every `higgsfield …` example in the docs is a real, current command.
 
 ## Breaking changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## What this is
 
-Three skills that drive the [`hf` CLI](https://github.com/higgsfield-ai/cli) to call Higgsfield API endpoints — image and video generation, Soul Character training, branded product photography.
+Three skills that drive the [`higgsfield` CLI](https://github.com/higgsfield-ai/cli) to call Higgsfield API endpoints — image and video generation, Soul Character training, branded product photography.
 
 ```
 higgsfield-soul     →  trains identity, returns reference_id
-higgsfield-generate →  consumes reference_id, plus 35+ models, plus Marketing Studio
+higgsfield-generate →  consumes reference_id, plus 30+ models, plus Marketing Studio
 higgsfield-product-photoshoot  →  self-contained, brand visuals via gpt_image_2
 ```
 
@@ -58,13 +58,13 @@ skills/
 
 ## API conventions
 
-All skills route through one binary: the [`hf` CLI](https://github.com/higgsfield-ai/cli). **Do not call `api.higgsfield.ai` directly with curl.** The CLI handles auth, retries, polling, schema validation, and auto-uploads. Skipping it bypasses critical behavior.
+All skills route through one binary: the [`higgsfield` CLI](https://github.com/higgsfield-ai/cli). **Do not call `api.higgsfield.ai` directly with curl.** The CLI handles auth, retries, polling, schema validation, and auto-uploads. Skipping it bypasses critical behavior.
 
-- Auth: `HEYGEN_API_KEY` env var OR `hf auth login` (persists to `~/.higgsfield/credentials`).
-- Pattern: `hf <noun> <verb>` — e.g. `hf generate create`, `hf soul create`, `hf product-photoshoot create`, `hf marketing-studio products fetch`.
-- Polling: `hf <noun> wait <id>` blocks until terminal status, prints result URL on stdout.
+- Auth: `HEYGEN_API_KEY` env var OR `higgsfield auth login` (persists to `~/.higgsfield/credentials`).
+- Pattern: `higgsfield <noun> <verb>` — e.g. `higgsfield generate create`, `higgsfield soul-id create`, `higgsfield product-photoshoot create`, `higgsfield marketing-studio products fetch`.
+- Polling: `higgsfield <noun> wait <id>` blocks until terminal status, prints result URL on stdout.
 - Media inputs: every `--image`, `--start-image`, `--video`, etc. flag accepts a local path (auto-uploaded) OR a UUID (upload id or previous job id).
-- Source of truth: never invent model names. Run `hf model list` for the live catalog. Reference catalogs in `references/model-catalog.md` are mappings (intent → model), not the model database.
+- Source of truth: never invent model names. Run `higgsfield model list` for the live catalog. Reference catalogs in `references/model-catalog.md` are mappings (intent → model), not the model database.
 
 ## The 300-line rule
 
@@ -82,7 +82,7 @@ Each `SKILL.md` should aim for under 300 lines. Skill files are loaded into the 
 
 **What moves to references/:**
 
-- `hf` command examples and full flag tables.
+- `higgsfield` command examples and full flag tables.
 - Asset classification tables and routing matrices.
 - Prompt galleries and style preset libraries.
 - Error handling patterns and troubleshooting trees.
@@ -114,7 +114,7 @@ CI fails if any drift. Don't bump versions by hand on feature branches — let r
 Skills communicate through return values, not implicit state.
 
 - `higgsfield-soul` returns a `reference_id` (Soul Character).
-- `higgsfield-generate` consumes it via `--custom_reference_id` for Soul-aware models (`text2image_soul_v2`, `soul_cinema_studio`) or as `custom` avatar in Marketing Studio.
+- `higgsfield-generate` consumes it via `--soul-id` for Soul-aware models (`text2image_soul_v2`, `soul_cinema_studio`) or as `custom` avatar in Marketing Studio.
 - `higgsfield-product-photoshoot` does not chain — it owns its own pipeline.
 
 When the user asks for both identity AND output in one request ("train Soul on these photos AND make a video of me"), run `higgsfield-soul` first, then `higgsfield-generate`. Don't batch-ask questions across skills — finish Soul, then start the video conversation.
@@ -135,5 +135,5 @@ Until then, treat any major default (model selection, mode selection, prompt enh
 
 ## Related projects
 
-- [`hf` CLI](https://github.com/higgsfield-ai/cli) — the binary every skill drives.
+- [`higgsfield` CLI](https://github.com/higgsfield-ai/cli) — the binary every skill drives.
 - [Agent Skills spec](https://agentskills.io/specification.md) — frontmatter format and validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Before merging, confirm:
 4. **No orphan reference files.** Every file inside `<skill>/references/` is mentioned at least once in that skill's `SKILL.md`. If it isn't reachable, delete it or link it.
 5. **`marketplace.json` is up to date.** If you added or renamed a skill folder, update the `skills` array in `.claude-plugin/marketplace.json`.
 6. **UX rules unchanged or stricter.** Don't loosen rules like "no raw IDs in chat", "polling is silent", "detect language and respond in it" without an explicit reason in the PR description.
-7. **CLI commands are real.** Every `hf …` example in your SKILL.md or references must be a real, current command. Run it locally before merging.
+7. **CLI commands are real.** Every `higgsfield …` example in your SKILL.md or references must be a real, current command. Run it locally before merging.
 8. **Behavior change → docs change.** If you changed defaults, mode-selection logic, or chain semantics, the affected `SKILL.md` reflects it. An agent reading only `SKILL.md` should be able to execute the skill correctly.
 
 ## Adding a new skill

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -23,7 +23,7 @@ Train my Soul on this headshot, then make 5 lifestyle photos of my product
 1. **Soul training** (`higgsfield-soul`):
 
    ```bash
-   hf soul create --name "founder" --soul-2 \
+   higgsfield soul-id create --name "founder" --soul-2 \
      --image headshot1.png --image headshot2.png ... \
      --max-train-steps 1000
    ```
@@ -33,7 +33,7 @@ Train my Soul on this headshot, then make 5 lifestyle photos of my product
 2. **Lifestyle photos** (`higgsfield-product-photoshoot`):
 
    ```bash
-   hf product-photoshoot create \
+   higgsfield product-photoshoot create \
      --mode lifestyle_scene \
      --prompt "founder using product in 5 distinct IG-feed scenes: morning coffee setup, desk workspace, outdoor café, gym, home office" \
      --image bottle.jpg \
@@ -46,7 +46,7 @@ Train my Soul on this headshot, then make 5 lifestyle photos of my product
 3. **Pick top 2 → animate** (`higgsfield-generate`, image-to-video):
 
    ```bash
-   hf generate create kling3_0 \
+   higgsfield generate create kling3_0 \
      --prompt "subtle product reveal, camera slowly pulls back, ambient motion" \
      --start-image ./campaign/photos/lifestyle-01.jpg \
      --duration 5 \
@@ -81,7 +81,7 @@ angles: organic UGC, unboxing reveal, presenter review, and a TV-spot version.
 1. **Product fetch:**
 
    ```bash
-   hf marketing-studio products fetch \
+   higgsfield marketing-studio products fetch \
      --url https://shop.example.com/sneakers \
      --wait
    ```
@@ -91,7 +91,7 @@ angles: organic UGC, unboxing reveal, presenter review, and a TV-spot version.
 2. **Pick preset avatar:**
 
    ```bash
-   hf marketing-studio avatars list --json | jq '.[] | select(.tags | contains(["sporty"]))'
+   higgsfield marketing-studio avatars list --json | jq '.[] | select(.tags | contains(["sporty"]))'
    ```
 
    Picks one matching the brand voice. No user input needed for the typical case.
@@ -100,7 +100,7 @@ angles: organic UGC, unboxing reveal, presenter review, and a TV-spot version.
 
    ```bash
    for mode in ugc ugc_unboxing product_review tv_spot; do
-     hf generate create marketing_studio_video \
+     higgsfield generate create marketing_studio_video \
        --prompt "<short hook tied to the mode>" \
        --avatars '[{"id":"<avatar_id>","type":"preset"}]' \
        --product_ids '[<product_id>]' \
@@ -149,7 +149,7 @@ Landscape, neutral background, conversational tone.
 **What the agent does (one-time setup):**
 
 ```bash
-hf soul create --name "founder" --soul-2 \
+higgsfield soul-id create --name "founder" --soul-2 \
   --image photo01.png --image photo02.png ... \
   --output-dir ./identity
 ```
@@ -162,13 +162,13 @@ Option A — Marketing Studio with custom avatar (recommended for branded look):
 
 ```bash
 # One-time: register the Soul as a custom avatar
-hf marketing-studio avatars create \
+higgsfield marketing-studio avatars create \
   --name "Founder" \
   --image <upload_id> \
   --image-url <cloudfront_url>
 # Returns avatar_id
 
-hf generate create marketing_studio_video \
+higgsfield generate create marketing_studio_video \
   --prompt "<full script with scene labels>" \
   --avatars '[{"id":"<avatar_id>","type":"custom"}]' \
   --mode ugc \
@@ -179,9 +179,9 @@ hf generate create marketing_studio_video \
 Option B — direct Soul model (more direct, less branded staging):
 
 ```bash
-hf generate create soul_cinema_studio \
+higgsfield generate create soul_cinema_studio \
   --prompt "<full script>" \
-  --custom_reference_id <reference_id> \
+  --soul-id <reference_id> \
   --duration 60 \
   --aspect_ratio 16:9
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 Three skills ship in this repo:
 
-- **`higgsfield-generate`** — image and video generation, 35+ models, plus Marketing Studio (branded ads with avatars and imported products)
+- **`higgsfield-generate`** — image and video generation, 30+ models, plus Marketing Studio (branded ads with avatars and imported products)
 - **`higgsfield-soul`** — train a face-faithful Soul Character
 - **`higgsfield-product-photoshoot`** — brand-quality product imagery with mode-specific prompt enhancement
 
@@ -10,11 +10,11 @@ They chain: `higgsfield-soul` returns a reference id consumable by `higgsfield-g
 
 ## Prerequisites
 
-Install the `hf` CLI:
+Install Higgsfield CLI:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
-hf auth login
+higgsfield auth login
 ```
 
 ## Option 1 — Claude Code
@@ -63,7 +63,7 @@ In your agent, ask:
 
 > "Generate a minimal test image with Higgsfield."
 
-The agent should invoke `higgsfield-generate`, run `hf generate create z_image --prompt "test"`, and deliver a URL.
+The agent should invoke `higgsfield-generate`, run `higgsfield generate create z_image --prompt "test"`, and deliver a URL.
 
 ## Updating
 

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -2,7 +2,7 @@
 
 You are an AI coding agent. The user asked you to install Higgsfield skills. Follow this exactly.
 
-## Step 1 — Install the `hf` CLI
+## Step 1 — Install Higgsfield CLI
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
@@ -14,19 +14,19 @@ The script asks for sudo password to write to `/usr/local/bin/`. If sudo isn't a
 curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh -s -- --prefix=$HOME/.local
 ```
 
-Verify: `hf version`. Expect `hf v0.1.X (...) built ...`.
+Verify: `higgsfield version`. Expect `higgsfield v0.1.X (...) built ...`.
 
 ## Step 2 — Authenticate
 
 Ask the user to run:
 
 ```bash
-hf auth login
+higgsfield auth login
 ```
 
 This opens a browser for OAuth. Wait for them to confirm.
 
-Verify: `hf account status`. Expect `<email> — <plan> plan, <N> credits`.
+Verify: `higgsfield account status`. Expect `<email> — <plan> plan, <N> credits`.
 
 ## Step 3 — Install the skills
 
@@ -51,7 +51,7 @@ Ask the agent (yourself):
 
 > "Generate a tiny test image with Higgsfield."
 
-Run `hf generate create z_image --prompt "test"`. Capture the job id. Run `hf generate wait <id>`. Confirm a URL is returned.
+Run `higgsfield generate create z_image --prompt "test"`. Capture the job id. Run `higgsfield generate wait <id>`. Confirm a URL is returned.
 
 If anything fails:
 - 401 / `Session expired` → repeat Step 2

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Quick path (Claude Code):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
-hf auth login
+higgsfield auth login
 git clone https://github.com/higgsfield-ai/skills.git ~/.claude/skills/higgsfield
 ```
 
 ```text
 "Generate a cinematic shot of a fox in a snowy forest, golden hour."
 → picks a photorealistic image model
-→ submits via the hf CLI
+→ submits via the higgsfield CLI
 → delivers the result URL
 
 "Train my Soul on these 10 photos, then make a 9:16 UGC ad of me holding the product."
@@ -37,7 +37,7 @@ git clone https://github.com/higgsfield-ai/skills.git ~/.claude/skills/higgsfiel
 
 | Skill | Invoke | Description |
 |---|---|---|
-| [`higgsfield-generate`](./higgsfield-generate) | `/higgsfield:generate` | Image and video generation across 35+ models (Nano Banana 2, Soul V2, Veo 3.1, Kling 3.0, Seedance 2.0, Flux 2, GPT Image 2, …) plus Marketing Studio for branded ads with avatars and imported products. |
+| [`higgsfield-generate`](./higgsfield-generate) | `/higgsfield:generate` | Image and video generation across 30+ models (Nano Banana 2, Soul V2, Veo 3.1, Kling 3.0, Seedance 2.0, Flux 2, GPT Image 2, …) plus Marketing Studio for branded ads with avatars and imported products. |
 | [`higgsfield-soul`](./higgsfield-soul) | `/higgsfield:soul` | Train a Soul Character — a reusable, face-faithful identity model. Returns a `reference_id` consumable by Soul-aware generation. |
 | [`higgsfield-product-photoshoot`](./higgsfield-product-photoshoot) | `/higgsfield:product-photoshoot` | Brand-quality product imagery with mode-specific prompt enhancement. 10 modes (studio, lifestyle, Pinterest, hero banner, ad packs, virtual try-on, …) backed by `gpt_image_2`. |
 
@@ -79,7 +79,7 @@ The skills chain: train Soul → use the reference id in `generate` (including M
 | What you want | Skill | Note |
 |---|---|---|
 | Generate any image / video from a prompt | `higgsfield-generate` | Prefers `gpt_image_2` / `nano_banana_2` for images and `seedance_2_0` for video by default |
-| Image with my own face | `higgsfield-soul` then `higgsfield-generate` | One-time training, then `--custom_reference_id` |
+| Image with my own face | `higgsfield-soul` then `higgsfield-generate` | One-time training, then `--soul-id` |
 | Branded product photo (studio / lifestyle / Pinterest / hero / ad pack) | `higgsfield-product-photoshoot` | Mode-specific prompt enhancer + `gpt_image_2` |
 | Branded ad video / UGC / unboxing / TV spot | `higgsfield-generate` | Marketing Studio mode with avatars + products |
 | Train a custom face identity | `higgsfield-soul` | 5–20 photos, returns `reference_id` |
@@ -87,7 +87,7 @@ The skills chain: train Soul → use the reference id in `generate` (including M
 
 ## How it works
 
-The skills are pure Markdown instructions. They drive the [`hf` CLI](https://github.com/higgsfield-ai/cli) to call Higgsfield API endpoints. No MCP server, no extra runtime — just one binary.
+The skills are pure Markdown instructions. They drive the [`higgsfield` CLI](https://github.com/higgsfield-ai/cli) to call Higgsfield API endpoints. No MCP server, no extra runtime — just one binary.
 
 Each skill is self-contained: its own `references/` directory bundles deep-dive docs (model catalog, prompt engineering, troubleshooting) loaded on-demand by the agent rather than every turn.
 

--- a/evals/scenarios.md
+++ b/evals/scenarios.md
@@ -17,7 +17,7 @@ These exist to be run by a human (or by another agent acting as the user) in a f
 - Picks `nano_banana_2`, `flux_2`, or another photorealistic-default model.
 - Does NOT pick a Soul model (no face mentioned).
 - Does NOT pick `gpt_image_2` (overkill for "quick").
-- Submits via `hf generate create <model> --prompt "..."`.
+- Submits via `higgsfield generate create <model> --prompt "..."`.
 - Polls silently (no "checking status..." spam).
 - Delivers ONE URL with a short summary.
 
@@ -62,9 +62,9 @@ These exist to be run by a human (or by another agent acting as the user) in a f
 **Expected behavior:**
 
 - Picks `--soul-2` (default).
-- Submits `hf soul create --name founder --soul-2 --image ... --image ...`.
+- Submits `higgsfield soul-id create --name founder --soul-2 --image ... --image ...`.
 - Polls silently. Soul training takes 15–45 min.
-- Delivers: "Soul `founder` ready. Use in generate with `--custom_reference_id <id>`."
+- Delivers: "Soul `founder` ready. Use in generate with `--soul-id <id>`."
 - Does NOT print the raw `reference_id` in chat (UX rule).
 
 **Score:**
@@ -85,7 +85,7 @@ These exist to be run by a human (or by another agent acting as the user) in a f
 
 - Looks up the existing Soul reference (asks user for the id, OR detects from a workspace state file if one exists).
 - Picks `text2image_soul_v2` or `soul_cinema_studio` (the cinematic variant fits the "cinematic" word).
-- Passes `--custom_reference_id <id>`.
+- Passes `--soul-id <id>`.
 - Does NOT re-train Soul.
 - Delivers ONE URL.
 
@@ -107,8 +107,8 @@ These exist to be run by a human (or by another agent acting as the user) in a f
 
 - Picks `--mode pinterest_pin`.
 - NOT `lifestyle_scene` or `product_shot`.
-- Calls `hf product-photoshoot create --mode pinterest_pin --image candle.jpg --prompt "..."`.
-- Does NOT call `hf generate create gpt_image_2 ...` directly (must go through the prompt enhancer).
+- Calls `higgsfield product-photoshoot create --mode pinterest_pin --image candle.jpg --prompt "..."`.
+- Does NOT call `higgsfield generate create gpt_image_2 ...` directly (must go through the prompt enhancer).
 - Asks ≤4 short questions (count, mood, anything to emphasize). Mode is obvious from the request.
 - Delivers ONE URL or a short bulleted list if `--count > 1`.
 
@@ -148,9 +148,9 @@ These exist to be run by a human (or by another agent acting as the user) in a f
 
 **Expected behavior:**
 
-- Calls `hf marketing-studio products fetch --url ... --wait` first.
-- Then lists/picks an avatar (`hf marketing-studio avatars list`).
-- Then `hf generate create marketing_studio_video` with `--mode ugc`, `--duration 15`, `--aspect_ratio 9:16`.
+- Calls `higgsfield marketing-studio products fetch --url ... --wait` first.
+- Then lists/picks an avatar (`higgsfield marketing-studio avatars list`).
+- Then `higgsfield generate create marketing_studio_video` with `--mode ugc`, `--duration 15`, `--aspect_ratio 9:16`.
 - Asks one question at a time. Does NOT batch-ask (avatar + product + mode + duration upfront).
 
 **Score:**
@@ -211,7 +211,7 @@ These exist to be run by a human (or by another agent acting as the user) in a f
 **Expected behavior:**
 
 - Notices the model name is unfamiliar.
-- Runs `hf model list` to verify.
+- Runs `higgsfield model list` to verify.
 - Reports back: "supernova_v9 isn't in the catalog. Suggested alternatives: …".
 - Does NOT submit with a fabricated model name.
 

--- a/higgsfield-generate/SKILL.md
+++ b/higgsfield-generate/SKILL.md
@@ -2,7 +2,7 @@
 version: 0.3.0
 name: higgsfield-generate
 description: |
-  Generate images and videos via Higgsfield AI through 35+ models including
+  Generate images and videos via Higgsfield AI through 30+ models including
   Nano Banana 2, Soul V2, Veo 3.1, Kling 3.0, Seedance 2.0, Flux 2, GPT Image 2,
   plus Marketing Studio for branded ad video/image with curated avatars and
   imported products.
@@ -27,17 +27,17 @@ allowed-tools: Bash
 
 # Higgsfield Generate
 
-Submit jobs to any Higgsfield model. Wraps the `hf` CLI. Covers generic image/video gen and Marketing Studio (branded ads, avatars, products).
+Submit jobs to any Higgsfield model. Wraps the `higgsfield` CLI. Covers generic image/video gen and Marketing Studio (branded ads, avatars, products).
 
 ## Prerequisites
 
-- `hf` CLI installed: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`
-- Authenticated: `hf auth login`
+- `higgsfield` CLI installed: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`
+- Authenticated: `higgsfield auth login`
 
 ## UX Rules
 
 1. Be concise. No raw IDs, no JSON dumps in chat. Print result URL when ready.
-2. No internal jargon. Don't narrate "calling hf cost", "polling job".
+2. No internal jargon. Don't narrate "calling higgsfield cost", "polling job".
 3. Detect the user's language from the first message and reply in it. Technical args (`--aspect_ratio 16:9`) stay English.
 4. Don't batch-ask. Pick a sane default model and ask one thing at a time only if genuinely missing.
 5. Don't pre-estimate cost. Just submit unless the user asks.
@@ -69,12 +69,12 @@ Submit jobs to any Higgsfield model. Wraps the `hf` CLI. Covers generic image/vi
    - Cheap with strong physics, no audio needed → Minimax Hailuo
    - Fast batch / volume → Veo 3.1 Lite
 
-   For the actual `--model` ID to pass to `hf generate create`, run `hf model list --json | jq` to map display names to IDs. See `references/model-catalog.md` for the full table.
+   For the actual `--model` ID to pass to `higgsfield generate create`, run `higgsfield model list --json | jq` to map display names to IDs. See `references/model-catalog.md` for the full table.
 
 2. **Pass media inputs straight to flags.** Media flags accept a local file path **or** a UUID. CLI auto-uploads paths and auto-detects job vs upload for UUIDs. No need to pre-upload. Each model declares accepted roles (`image`, `start_image`, `end_image`, `video`, `audio`) — see `references/media-inputs.md`.
-3. **Validate quickly.** If unsure of params, run `hf model get <jst> --json` once and pass only what's needed. Use schema defaults otherwise. The server returns `adjustments` for non-fatal coercions (e.g. `aspect_ratio=99:99` → closest match) and a structured error for invalid declared-param values.
-4. **Submit.** `hf generate create <jst> --prompt "..." [media flags] [param flags]`. Capture job id.
-5. **Wait.** `hf generate wait <id>` — blocks until terminal, prints result URL on stdout.
+3. **Validate quickly.** If unsure of params, run `higgsfield model get <jst> --json` once and pass only what's needed. Use schema defaults otherwise. The server returns `adjustments` for non-fatal coercions (e.g. `aspect_ratio=99:99` → closest match) and a structured error for invalid declared-param values.
+4. **Submit.** `higgsfield generate create <jst> --prompt "..." [media flags] [param flags]`. Capture job id.
+5. **Wait.** `higgsfield generate wait <id>` — blocks until terminal, prints result URL on stdout.
 6. **Deliver.** Send the URL plus a one-line summary (model, duration if video).
 
 ## Media flags
@@ -87,20 +87,20 @@ Submit jobs to any Higgsfield model. Wraps the `hf` CLI. Covers generic image/vi
 | `--video <path-or-id>` | reference video | `seedance_2_0` |
 | `--audio <path-or-id>` | reference audio (lipsync, soundtrack match) | `seedance_2_0` (use this, NOT `--generate-audio`) |
 
-Each flag accepts either a local file path (auto-uploaded) or a UUID (upload id from `hf upload create`, or a previous job id). Each model declares its own role set via `MEDIA_ROLES`. See `references/media-inputs.md` for the full table.
+Each flag accepts either a local file path (auto-uploaded) or a UUID (upload id from `higgsfield upload create`, or a previous job id). Each model declares its own role set via `MEDIA_ROLES`. See `references/media-inputs.md` for the full table.
 
 ## Common params
 
-Flags pass through to model schema. Use `hf model get <jst>` to discover.
+Flags pass through to model schema. Use `higgsfield model get <jst>` to discover.
 
 ```bash
-hf generate create gpt_image_2 --prompt "neon city at dusk" --aspect_ratio 16:9 --resolution 2k
-hf generate create nano_banana_2 --prompt "anime character concept, expressive pose" --image ./ref.png
-hf generate create seedance_2_0 --prompt "camera dollies in" --start-image ./first.png --duration 8
-hf generate create text2image_soul_v2 --prompt "..." --custom_reference_id <soul_ref_id>
+higgsfield generate create gpt_image_2 --prompt "neon city at dusk" --aspect_ratio 16:9 --resolution 2k
+higgsfield generate create nano_banana_2 --prompt "anime character concept, expressive pose" --image ./ref.png
+higgsfield generate create seedance_2_0 --prompt "camera dollies in" --start-image ./first.png --duration 8
+higgsfield generate create text2image_soul_v2 --prompt "..." --soul-id <soul_ref_id>
 ```
 
-Stdin prompt: `echo "..." | hf generate create z_image`.
+Stdin prompt: `echo "..." | higgsfield generate create z_image`.
 
 ## Marketing Studio
 
@@ -108,8 +108,8 @@ Branded image/video gen: avatars + products + ad-style modes. Use models `market
 
 ### Concepts
 
-- **Avatar** — presenter face. Curated `preset` (browse `hf marketing-studio avatars list`) or `custom` (uploaded photos via `hf marketing-studio avatars create`).
-- **Product** — brand item with title + reference images. Imported from URL (`hf marketing-studio products fetch --url ...`) or created from uploaded images (`hf marketing-studio products create`).
+- **Avatar** — presenter face. Curated `preset` (browse `higgsfield marketing-studio avatars list`) or `custom` (uploaded photos via `higgsfield marketing-studio avatars create`).
+- **Product** — brand item with title + reference images. Imported from URL (`higgsfield marketing-studio products fetch --url ...`) or created from uploaded images (`higgsfield marketing-studio products create`).
 - **Webproduct** — App Store / web page version. Auto-routes when fetching App Store URLs.
 
 ### UX rules (additional)
@@ -119,16 +119,16 @@ Branded image/video gen: avatars + products + ad-style modes. Use models `market
 ### Workflow — quick ad video
 
 1. **Get product.**
-   - URL → `hf marketing-studio products fetch --url <url> --wait` (polls until import done)
-   - Local images → `hf upload create <photo>...` then `hf marketing-studio products create --title "..." --image <id>...`
+   - URL → `higgsfield marketing-studio products fetch --url <url> --wait` (polls until import done)
+   - Local images → `higgsfield upload create <photo>...` then `higgsfield marketing-studio products create --title "..." --image <id>...`
    Capture product id.
 2. **Pick avatar.**
-   - Default: `hf marketing-studio avatars list` and pick a preset matching the brand voice.
-   - Custom: `hf marketing-studio avatars create --name "..." --image <upload_id>`.
+   - Default: `higgsfield marketing-studio avatars list` and pick a preset matching the brand voice.
+   - Custom: `higgsfield marketing-studio avatars create --name "..." --image <upload_id>`.
 3. **Pick mode.** Default `ugc`. Other slugs (canonical from MCP): `ugc_how_to`, `ugc_unboxing`, `product_showcase`, `product_review`, `tv_spot`, `wild_card`, `ugc_virtual_try_on`, `virtual_try_on`. See `references/marketing-modes.md`.
 4. **Generate.**
    ```bash
-   hf generate create marketing_studio_video \
+   higgsfield generate create marketing_studio_video \
      --prompt "..." \
      --avatars '[{"id":"<avatar_id>","type":"preset"}]' \
      --product_ids '[<product_id>]' \
@@ -138,7 +138,7 @@ Branded image/video gen: avatars + products + ad-style modes. Use models `market
      --aspect_ratio 9:16
    ```
    Resolution is `480p` or `720p`. Aspect ratio is one of `auto`/`21:9`/`16:9`/`4:3`/`1:1`/`3:4`/`9:16`. `--generate-audio true` is supported here (unlike `seedance_2_0`).
-5. **Wait.** `hf generate wait <id>`.
+5. **Wait.** `higgsfield generate wait <id>`.
 6. **Deliver.** URL + one-line summary (mode, duration).
 
 ### Click-to-Ad shortcut (URL-driven)
@@ -147,10 +147,10 @@ When the user gives a product URL and wants a marketing video in one go:
 
 ```bash
 # 1. Trigger fetch (returns the product id and starts background scrape)
-hf marketing-studio products fetch --url https://shop.example.com/sneakers --wait
+higgsfield marketing-studio products fetch --url https://shop.example.com/sneakers --wait
 
 # 2. Generate the marketing video against the same URL — backend reuses the entity
-hf generate create marketing_studio_video \
+higgsfield generate create marketing_studio_video \
   --url https://shop.example.com/sneakers \
   --mode ugc \
   --duration 15 \
@@ -164,7 +164,7 @@ Backend dedupes by URL, so repeated runs reuse the existing entity instead of re
 Same as above but use `marketing_studio_image` model:
 
 ```bash
-hf generate create marketing_studio_image \
+higgsfield generate create marketing_studio_image \
   --prompt "..." \
   --aspect_ratio 1:1 \
   --resolution 2k
@@ -174,8 +174,8 @@ hf generate create marketing_studio_image \
 
 - `Missing required params: prompt` → user gave no prompt; ask for it.
 - `Invalid values: aspect_ratio=99:99 (allowed: ...)` → bad enum; pick from allowed.
-- `Unknown params: foo` → schema doesn't accept that flag; check `hf model get <jst>`.
-- `Session expired` → `hf auth login`.
+- `Unknown params: foo` → schema doesn't accept that flag; check `higgsfield model get <jst>`.
+- `Session expired` → `higgsfield auth login`.
 
 See `references/troubleshooting.md` for more.
 

--- a/higgsfield-generate/references/marketing-avatars.md
+++ b/higgsfield-generate/references/marketing-avatars.md
@@ -12,8 +12,8 @@
 ## Listing presets
 
 ```bash
-hf marketing-studio avatars list
-hf marketing-studio avatars list --json | jq '.[] | select(.gender=="female")'
+higgsfield marketing-studio avatars list
+higgsfield marketing-studio avatars list --json | jq '.[] | select(.gender=="female")'
 ```
 
 Filter by `name`, `gender`, etc. on the JSON output.
@@ -21,9 +21,9 @@ Filter by `name`, `gender`, etc. on the JSON output.
 ## Creating a custom avatar
 
 ```bash
-ID=$(hf upload create founder.png)
-URL=$(hf upload create founder.png --json | jq -r .url)   # if you need cloudfront URL
-hf marketing-studio avatars create --name "Founder" --image $ID --image-url $URL
+ID=$(higgsfield upload create founder.png)
+URL=$(higgsfield upload create founder.png --json | jq -r .url)   # if you need cloudfront URL
+higgsfield marketing-studio avatars create --name "Founder" --image $ID --image-url $URL
 ```
 
 `--image-url` is the cloudfront URL from the upload. Required by the API.
@@ -31,7 +31,7 @@ hf marketing-studio avatars create --name "Founder" --image $ID --image-url $URL
 ## Passing to video
 
 ```bash
-hf generate create marketing_studio_video \
+higgsfield generate create marketing_studio_video \
   --avatars '[{"id":"<avatar_id>","type":"preset"}]' \
   ...
 ```

--- a/higgsfield-generate/references/marketing-modes.md
+++ b/higgsfield-generate/references/marketing-modes.md
@@ -30,11 +30,11 @@ Canonical mode values for `marketing_studio_video` `--mode`. Mirrored from the M
 For `marketing_studio_video`, the API accepts:
 
 - `aspect_ratio`: `auto`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, `9:16` (default `16:9`).
-- `duration`: integer ≥ 4 seconds. No fixed cap; check `hf model get marketing_studio_video` for the current upper bound.
+- `duration`: integer ≥ 4 seconds. No fixed cap; check `higgsfield model get marketing_studio_video` for the current upper bound.
 - `resolution`: `480p` or `720p` (default `720p`).
 - `generate_audio`: boolean (default `false`). Generates audio for the video.
 - `avatars`: array of `{id, type}` where `type` is `preset` or `custom`. See `marketing-avatars.md`.
-- `product_ids`: array of product UUIDs (from `hf marketing-studio products fetch` or `create`). See `marketing-products.md`.
+- `product_ids`: array of product UUIDs (from `higgsfield marketing-studio products fetch` or `create`). See `marketing-products.md`.
 - `medias`: optional reference images with role `image`, `start_image`, or `end_image`.
 - `feature: "click_to_ad"`: when generating from a single landing-page URL (Click-to-Ad flow).
 - `product: { id?, url? }`: alternative single-product reference; the URL flow auto-fetches.
@@ -43,7 +43,7 @@ For `marketing_studio_video`, the API accepts:
 
 For `marketing_studio_video` driven by a product URL (no manual product create / fetch), the MCP-side flow is:
 
-1. Call `hf marketing-studio products fetch --url <url> --wait` (or use `show_marketing_studio` widget action `fetch`).
-2. Call `hf generate create marketing_studio_video --url <same url>` — the backend looks up / reuses the entity and submits.
+1. Call `higgsfield marketing-studio products fetch --url <url> --wait` (or use `show_marketing_studio` widget action `fetch`).
+2. Call `higgsfield generate create marketing_studio_video --url <same url>` — the backend looks up / reuses the entity and submits.
 
 Repeated fetches for the same URL dedupe — the backend reuses any existing non-failed entity.

--- a/higgsfield-generate/references/marketing-products.md
+++ b/higgsfield-generate/references/marketing-products.md
@@ -5,7 +5,7 @@ Two ways to register a product: URL fetch (auto-imports title, description, imag
 ## URL fetch (default)
 
 ```bash
-ID=$(hf marketing-studio products fetch --url https://shop.example.com/sneakers --wait --json | jq -r .id)
+ID=$(higgsfield marketing-studio products fetch --url https://shop.example.com/sneakers --wait --json | jq -r .id)
 ```
 
 `--wait` polls until `status` is `completed` or `failed`. Default timeout 90s.
@@ -15,7 +15,7 @@ If `failed`, check `fail_reason` — usually invalid URL or scrape blocked.
 App Store URLs auto-route to `webproducts` (different endpoint). Use:
 
 ```bash
-hf marketing-studio webproducts fetch --url https://apps.apple.com/... --wait
+higgsfield marketing-studio webproducts fetch --url https://apps.apple.com/... --wait
 ```
 
 ## Manual
@@ -23,9 +23,9 @@ hf marketing-studio webproducts fetch --url https://apps.apple.com/... --wait
 When the user has product photos and details:
 
 ```bash
-A=$(hf upload create shoe1.png)
-B=$(hf upload create shoe2.png)
-hf marketing-studio products create \
+A=$(higgsfield upload create shoe1.png)
+B=$(higgsfield upload create shoe2.png)
+higgsfield marketing-studio products create \
   --title "AeroRun Pro" \
   --description "Lightweight running shoe" \
   --image $A --image $B
@@ -38,7 +38,7 @@ Returns the product entity directly (no polling needed).
 For App Store / web pages without URL fetch:
 
 ```bash
-hf marketing-studio webproducts create \
+higgsfield marketing-studio webproducts create \
   --url "https://example.com" \
   --title "MyApp" \
   --subtitle "Productivity for teams" \
@@ -51,6 +51,6 @@ hf marketing-studio webproducts create \
 ## Listing
 
 ```bash
-hf marketing-studio products list
-hf marketing-studio webproducts list
+higgsfield marketing-studio products list
+higgsfield marketing-studio webproducts list
 ```

--- a/higgsfield-generate/references/media-inputs.md
+++ b/higgsfield-generate/references/media-inputs.md
@@ -4,17 +4,17 @@ How to pass reference images, videos, and audio. Mirrored from MCP server media-
 
 ## Path or UUID — both work
 
-Each media flag accepts either a local file path or a UUID. The CLI auto-uploads paths before submission and auto-detects whether a UUID is an upload id (from `hf upload create`) or a previous job id.
+Each media flag accepts either a local file path or a UUID. The CLI auto-uploads paths before submission and auto-detects whether a UUID is an upload id (from `higgsfield upload create`) or a previous job id.
 
 ```bash
 # Local path — CLI uploads automatically
-hf generate create nano_banana_2 --prompt "stylize in watercolor" --image ./photo.png
+higgsfield generate create nano_banana_2 --prompt "stylize in watercolor" --image ./photo.png
 
-# Upload id (from hf upload create)
-hf generate create nano_banana_2 --prompt "..." --image <upload_id>
+# Upload id (from higgsfield upload create)
+higgsfield generate create nano_banana_2 --prompt "..." --image <upload_id>
 
 # Job id from a previous generation
-hf generate create seedance_2_0 --prompt "anim" --start-image <previous_job_id>
+higgsfield generate create seedance_2_0 --prompt "anim" --start-image <previous_job_id>
 ```
 
 Type auto-detected from extension:
@@ -41,7 +41,7 @@ Each model declares a closed set of accepted roles via `MEDIA_ROLES`. Pass the r
 For simple image-to-video on a video model that only declares `image` (e.g. `veo3`), plain `--image` is auto-remapped to `start_image` by the CLI when unambiguous. When in doubt:
 
 ```bash
-hf model get <model_id>   # shows the accepted media roles for this model
+higgsfield model get <model_id>   # shows the accepted media roles for this model
 ```
 
 ## Multiple images
@@ -49,7 +49,7 @@ hf model get <model_id>   # shows the accepted media roles for this model
 Most image models accept multiple references — repeat the `--image` flag:
 
 ```bash
-hf generate create nano_banana_2 --prompt "..." \
+higgsfield generate create nano_banana_2 --prompt "..." \
   --image ./a.png --image ./b.png --image <upload_id>
 ```
 
@@ -60,7 +60,7 @@ Single-reference video models (`veo3`, `veo3_1`, `kling2_6`) reject extra images
 `seedance_2_0` is the one model that takes an audio reference for lipsync / soundtrack matching. Pass via `medias` with role `audio`:
 
 ```bash
-hf generate create seedance_2_0 \
+higgsfield generate create seedance_2_0 \
   --prompt "person speaking" \
   --start-image ./headshot.png \
   --audio ./voice.mp3 \
@@ -75,12 +75,12 @@ The CLI returns specific error messages for known shape mismatches:
 
 - `Model accepts only --image (no roles)` — the model uses the legacy `input_images` shape, not `medias` with roles. Drop role-prefixed flags and use plain `--image`.
 - `Model does not accept media inputs` — the model is text-only (`z_image`, `soul_location`, `soul_cast`, `wan2_6` for some configs). Drop all media flags.
-- `Unknown media role "<role>"` — the role isn't in this model's `MEDIA_ROLES`. Run `hf model get <model>` and check `medias[].roles`.
+- `Unknown media role "<role>"` — the role isn't in this model's `MEDIA_ROLES`. Run `higgsfield model get <model>` and check `medias[].roles`.
 
 ## Seeing what a model accepts
 
 ```bash
-hf model get <model_id> --json | jq '{aspect_ratios, durations, parameters, medias}'
+higgsfield model get <model_id> --json | jq '{aspect_ratios, durations, parameters, medias}'
 ```
 
 Returns the full schema: aspect ratios (closed enum or open), durations (closed list or `min/max` range), parameters (with descriptions and defaults), and media roles per slot.

--- a/higgsfield-generate/references/model-catalog.md
+++ b/higgsfield-generate/references/model-catalog.md
@@ -1,6 +1,6 @@
 # Model Catalog
 
-The full lineup of generation models available through Higgsfield. Each entry has its own sweet spot — pick the one that matches your brief. For the actual `--model` ID to pass to `hf generate create`, run `hf model list --json` and look up by display name.
+The full lineup of generation models available through Higgsfield. Each entry has its own sweet spot — pick the one that matches your brief. For the actual `--model` ID to pass to `higgsfield generate create`, run `higgsfield model list --json` and look up by display name.
 
 Preferred defaults for examples and quick-start guidance in this repo:
 - **Images:** `gpt_image_2` (general/high-fidelity) and `nano_banana_2` (character/cartoon).
@@ -91,7 +91,7 @@ Practical defaults from production use. Match by intent, not surface keyword. Wh
 
 ### Things to keep in mind
 
-- **Don't invent model names.** Run `hf model list` if you're unsure — submitting an unknown model returns `unknown model "..."`.
+- **Don't invent model names.** Run `higgsfield model list` if you're unsure — submitting an unknown model returns `unknown model "..."`.
 - **Audio reference for Seedance 2.0** comes through the media inputs with role `audio`, not via a separate `generate_audio` flag.
 - **Text-only models reject reference images.** Z Image, Soul Cast, Soul Location, and some Wan configs are text-only; pass no media flags to them.
 - **Route branded product visuals through `higgsfield-product-photoshoot`** — its prompt enhancer adds 10 mode-specific templates on top of GPT Image 2. Direct GPT Image 2 generation here is the right call for everything that isn't a product photoshoot.
@@ -102,7 +102,7 @@ Practical defaults from production use. Match by intent, not surface keyword. Wh
 
 ## Media role conventions
 
-Each model accepts a fixed set of media roles. When unsure, run `hf model get <model>` and inspect the `medias[].roles` field.
+Each model accepts a fixed set of media roles. When unsure, run `higgsfield model get <model>` and inspect the `medias[].roles` field.
 
 | Model | Accepted media roles |
 |---|---|
@@ -122,7 +122,7 @@ For simple image-to-video, the `start_image` role is what you want. For pure vid
 These are model-specific. The CLI clamps unsupported values to the nearest allowed one (with a `Note: adjustments applied` warning) when the model declares a closed set. When in doubt:
 
 ```bash
-hf model get <model>
+higgsfield model get <model>
 ```
 
 Common patterns:

--- a/higgsfield-generate/references/prompt-engineering.md
+++ b/higgsfield-generate/references/prompt-engineering.md
@@ -37,7 +37,7 @@ Most models don't expose a `negative_prompt`. Phrase positively:
 - `16:9` — landscape, cinematic
 - `9:16` — vertical, social
 - `1:1` — square, profile / icon
-- `4:3`, `3:4`, `21:9` — model-dependent, check `hf model get <jst>`
+- `4:3`, `3:4`, `21:9` — model-dependent, check `higgsfield model get <jst>`
 
 ## Safety
 

--- a/higgsfield-generate/references/troubleshooting.md
+++ b/higgsfield-generate/references/troubleshooting.md
@@ -2,15 +2,15 @@
 
 ## Authentication
 
-- `Session expired.` → `hf auth login`
-- `Stored credentials are for ... but current environment ...` → `hf auth login` for the current API URL.
-- `Not authenticated.` → first `hf auth login`.
+- `Session expired.` → `higgsfield auth login`
+- `Stored credentials are for ... but current environment ...` → `higgsfield auth login` for the current API URL.
+- `Not authenticated.` → first `higgsfield auth login`.
 
 ## Validation
 
 - `Missing required params: prompt` — user gave no prompt. Ask.
 - `Invalid values: <param>=<v> (allowed: ...)` — pick from allowed enum.
-- `Unknown params: <name>` — schema doesn't accept this flag. Run `hf model get <jst>` and check.
+- `Unknown params: <name>` — schema doesn't accept this flag. Run `higgsfield model get <jst>` and check.
 
 ## Job lifecycle
 
@@ -28,4 +28,4 @@ If `Failed to decode response. Body: <html>...captcha-delivery...` appears, the 
 
 ## Cost
 
-`hf generate cost <jst> ...` returns credit estimate without submitting. Useful when the user asks "how much will this cost?".
+`higgsfield generate cost <jst> ...` returns credit estimate without submitting. Useful when the user asks "how much will this cost?".

--- a/higgsfield-product-photoshoot/SKILL.md
+++ b/higgsfield-product-photoshoot/SKILL.md
@@ -28,12 +28,12 @@ allowed-tools: Bash
 
 # Product Photoshoot
 
-Brand-image generation via the `hf product-photoshoot create` command. The CLI calls a backend prompt enhancer that holds mode-specific photography vocabulary and structural templates, then submits to `gpt_image_2` and returns image URLs.
+Brand-image generation via the `higgsfield product-photoshoot create` command. The CLI calls a backend prompt enhancer that holds mode-specific photography vocabulary and structural templates, then submits to `gpt_image_2` and returns image URLs.
 
 ## Prerequisites
 
-- `hf` CLI: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`
-- Authenticated: `hf auth login`
+- `higgsfield` CLI: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`
+- Authenticated: `higgsfield auth login`
 
 ## UX Rules
 
@@ -137,7 +137,7 @@ After answers → return to the relevant Type A–E.
 Single command. Backend assembles the final prompt and submits to `gpt_image_2`. URLs print on stdout.
 
 ```bash
-hf product-photoshoot create \
+higgsfield product-photoshoot create \
   --mode <mode> \
   --prompt "<short user-intent description from interview answers>" \
   [--image <path-or-upload-id>]... \
@@ -148,7 +148,7 @@ hf product-photoshoot create \
 Examples:
 
 ```bash
-hf product-photoshoot create \
+higgsfield product-photoshoot create \
   --mode lifestyle_scene \
   --prompt "bottle of cold-brew on a sunlit kitchen counter, IG feed" \
   --image bottle.jpg \
@@ -156,14 +156,14 @@ hf product-photoshoot create \
 ```
 
 ```bash
-hf product-photoshoot create \
+higgsfield product-photoshoot create \
   --mode pinterest_pin \
   --prompt "vertical pin for my candle brand, cottagecore mood" \
   --image candle.jpg
 ```
 
 ```bash
-hf product-photoshoot create \
+higgsfield product-photoshoot create \
   --mode restyle \
   --prompt "Christmas version, quiet-luxury aesthetic" \
   --image existing-shot.jpg
@@ -205,6 +205,6 @@ Print the image URLs as a short bulleted list. No JSON, no IDs, no internal mode
 
 - Asking more than 4 interview questions in a single message.
 - Picking the wrong mode (e.g. `product_shot` when the user wants a Pinterest pin).
-- Calling `hf gen create gpt_image_2 --prompt ...` directly instead of `hf product-photoshoot create` — bypasses the prompt enhancer and produces noticeably worse output.
+- Calling `higgsfield generate create gpt_image_2 --prompt ...` directly instead of `higgsfield product-photoshoot create` — bypasses the prompt enhancer and produces noticeably worse output.
 - Pasting the assembled prompt back to the user — they want the URLs.
 - Using a `--mode` value not in the table above.

--- a/higgsfield-soul/SKILL.md
+++ b/higgsfield-soul/SKILL.md
@@ -8,7 +8,7 @@ description: |
   "build me an avatar", "learn my appearance", "create a character of me",
   "set up identity for video", "I want my face in generated images".
   Chain: train Soul (one-time, returns reference_id) → use in
-  higgsfield-generate via `--custom_reference_id <id>` with models like
+  higgsfield-generate via `--soul-id <id>` with models like
   `text2image_soul_v2` or `soul_cinema_studio`.
   NOT for: one-shot face swaps (use higgsfield-generate with --image),
   named-character / non-photo avatars (use higgsfield-generate with prompt).
@@ -22,8 +22,8 @@ Train a face-faithful identity model. Reusable across all Soul-powered generatio
 
 ## Prerequisites
 
-- `hf` CLI: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`
-- Authenticated: `hf auth login`
+- `higgsfield` CLI: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`
+- Authenticated: `higgsfield auth login`
 - Paid plan (Basic+) — Soul training requires it.
 
 ## UX Rules
@@ -43,34 +43,34 @@ Train a face-faithful identity model. Reusable across all Soul-powered generatio
    Choose based on user's stated downstream use. Default to `--soul-2`.
 4. **Submit.**
    ```bash
-   hf soul create --name "<name>" --soul-2 --image ./photo1.png --image ./photo2.png ...
-   hf soul create --name "<name>" --soul-2 --image <upload_id> --image <upload_id> ...
+   higgsfield soul-id create --name "<name>" --soul-2 --image ./photo1.png --image ./photo2.png ...
+   higgsfield soul-id create --name "<name>" --soul-2 --image <upload_id> --image <upload_id> ...
    ```
    CLI auto-uploads paths. Captures returned reference id.
-5. **Wait.** `hf soul wait <id>`. Silent. Default timeout 30m.
-6. **Deliver.** "Soul `<name>` ready. Use in generate with `--custom_reference_id <id>`."
+5. **Wait.** `higgsfield soul-id wait <id>`. Silent. Default timeout 30m.
+6. **Deliver.** "Soul `<name>` ready. Use in generate with `--soul-id <id>`."
 
 ## Use the Soul
 
 Once trained, pass to `higgsfield-generate`:
 
 ```bash
-hf generate create text2image_soul_v2 --prompt "..." --custom_reference_id <ref_id>
-hf generate create soul_cinema_studio --prompt "..." --custom_reference_id <ref_id>
+higgsfield generate create text2image_soul_v2 --prompt "..." --soul-id <ref_id>
+higgsfield generate create soul_cinema_studio --prompt "..." --soul-id <ref_id>
 ```
 
 ## Listing existing Souls
 
 ```bash
-hf soul list                   # all references
-hf soul get <id>               # one by id
+higgsfield soul-id list                   # all references
+higgsfield soul-id get <id>               # one by id
 ```
 
 ## Errors
 
 - `Minimum Basic plan required` — user is on free plan; tell them.
 - `Training failed` — check photos quality (5+ unique faces, well-lit).
-- `Session expired` → `hf auth login`.
+- `Session expired` → `higgsfield auth login`.
 
 ## Reference docs
 

--- a/higgsfield-soul/references/troubleshooting.md
+++ b/higgsfield-soul/references/troubleshooting.md
@@ -17,8 +17,8 @@ Action: ask user to swap in better photos, retrain.
 
 ## `Session expired`
 
-`hf auth login`.
+`higgsfield auth login`.
 
 ## Slow training
 
-Default timeout is 30m. If still in progress: `hf soul wait <id> --timeout 60m`.
+Default timeout is 30m. If still in progress: `higgsfield soul-id wait <id> --timeout 60m`.


### PR DESCRIPTION
Skills referenced old CLI surface. Aligns with cli v0.1.23. Critical: hf soul -> higgsfield soul-id (old form fails with unknown command). Also: --custom_reference_id -> --soul-id, hf -> higgsfield everywhere, 35+ -> 30+.